### PR TITLE
Gui fixes dashboard

### DIFF
--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/charts/LatencyHistogramController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/charts/LatencyHistogramController.java
@@ -41,8 +41,6 @@ public class LatencyHistogramController extends FlowChartController {
         final PGIDStatsStorage pgIDStatsStorage = statsStorage.getPGIDStatsStorage();
         final Map<Integer, ArrayHistory<LatencyStatPoint>> latencyStatPointHistoryMap =
                 pgIDStatsStorage.getLatencyStatPointHistoryMap();
-        final Map<Integer, LatencyStatPoint> latencyStatPointShadowMap =
-                pgIDStatsStorage.getLatencyStatPointShadowMap();
         final String[] histogramKeys = pgIDStatsStorage.getHistogramKeys(HISTOGRAM_SIZE);
 
         final List<XYChart.Series<String, Long>> seriesList = new LinkedList<>();
@@ -58,18 +56,12 @@ public class LatencyHistogramController extends FlowChartController {
                     return;
                 }
 
-                final LatencyStatPoint latencyShadow = latencyStatPointShadowMap.get(pgID);
-                final Map<String, Long> shadowHistogram = latencyShadow != null ?
-                        latencyShadow.getLatencyStat().getLat().getHistogram() :
-                        new HashMap<>();
-
                 final Map<String, Long> histogram = history.last().getLatencyStat().getLat().getHistogram();
                 final XYChart.Series<String, Long> series = new XYChart.Series<>();
                 series.setName(String.valueOf(pgID));
                 for (final String key : histogramKeys) {
                     final long value = histogram.getOrDefault(key, 0L);
-                    final long shadowValue = shadowHistogram.getOrDefault(key, 0L);
-                    series.getData().add(new XYChart.Data<>(key, value - shadowValue));
+                    series.getData().add(new XYChart.Data<>(key, value));
                 }
                 setSeriesColor(series, color);
                 seriesList.add(series);

--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/latency/LatencyController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/latency/LatencyController.java
@@ -109,8 +109,6 @@ public class LatencyController extends FlowStatsBaseController {
                 pgIDStatsStorage.getFlowStatPointShadowMap();
         final Map<Integer, ArrayHistory<LatencyStatPoint>> latencyStatPointHistoryMap =
                 pgIDStatsStorage.getLatencyStatPointHistoryMap();
-        final Map<Integer, LatencyStatPoint> latencyStatPointShadowMap =
-                pgIDStatsStorage.getLatencyStatPointShadowMap();
         final Map<Integer, Long> maxLatencyMap = pgIDStatsStorage.getMaxLatencyMap();
         final Set<Integer> stoppedPGIds = pgIDStatsStorage.getStoppedPGIds();
 
@@ -156,11 +154,6 @@ public class LatencyController extends FlowStatsBaseController {
 
                 long totalErr = latencyStat.getErr().getTotal();
 
-                final LatencyStatPoint latencyShadow = latencyStatPointShadowMap.get(pgID);
-                if (latencyShadow != null) {
-                    totalErr -= latencyShadow.getLatencyStat().getErr().getTotal();
-                }
-
                 final LatencyStatLat lat = latencyStat.getLat();
 
                 final boolean isStopped = stoppedPGIds.contains(pgID);
@@ -188,8 +181,6 @@ public class LatencyController extends FlowStatsBaseController {
         final PGIDStatsStorage pgIDStatsStorage = StatsStorage.getInstance().getPGIDStatsStorage();
         final Map<Integer, ArrayHistory<LatencyStatPoint>> latencyStatPointHistoryMap =
                 pgIDStatsStorage.getLatencyStatPointHistoryMap();
-        final Map<Integer, LatencyStatPoint> latencyStatPointShadowMap =
-                pgIDStatsStorage.getLatencyStatPointShadowMap();
         final String[] histogramKeys = pgIDStatsStorage.getHistogramKeys(HISTOGRAM_SIZE);
         final Set<Integer> stoppedPGIds = pgIDStatsStorage.getStoppedPGIds();
 
@@ -224,29 +215,13 @@ public class LatencyController extends FlowStatsBaseController {
                 long sth = latencyStatErr.getSth();
                 long stl = latencyStatErr.getStl();
 
-                final LatencyStatPoint latencyShadow = latencyStatPointShadowMap.get(pgID);
-                Map<String, Long> shadowHistogram;
-                if (latencyShadow != null) {
-                    final LatencyStatErr latencyStatShadowErr = latencyShadow.getLatencyStat().getErr();
-                    drp -= latencyStatShadowErr.getDrp();
-                    dup -= latencyStatShadowErr.getDup();
-                    ooo -= latencyStatShadowErr.getOoo();
-                    sth -= latencyStatShadowErr.getSth();
-                    stl -= latencyStatShadowErr.getStl();
-
-                    shadowHistogram = latencyShadow.getLatencyStat().getLat().getHistogram();
-                } else {
-                    shadowHistogram = new HashMap<>();
-                }
-
                 final boolean isStopped = stoppedPGIds.contains(pgID);
 
                 int col = 0;
                 table.add(new HeaderCell(COLUMN_WIDTH, String.valueOf(pgID), isStopped), rowIndex, col++);
                 for (final String key : histogramKeys) {
                     final long value = histogram.getOrDefault(key, 0L);
-                    final long shadowValue = shadowHistogram.getOrDefault(key, 0L);
-                    table.add(new StatisticLabelCell(String.valueOf(value - shadowValue), COLUMN_WIDTH, col % 2 == 0, CellType.DEFAULT_CELL, true, isStopped), rowIndex, col++);
+                    table.add(new StatisticLabelCell(String.valueOf(value), COLUMN_WIDTH, col % 2 == 0, CellType.DEFAULT_CELL, true, isStopped), rowIndex, col++);
                 }
                 table.add(new StatisticLabelCell(String.valueOf(drp), COLUMN_WIDTH, col % 2 == 0, CellType.ERROR_CELL, true, isStopped), rowIndex, col++);
                 table.add(new StatisticLabelCell(String.valueOf(dup), COLUMN_WIDTH, col % 2 == 0, CellType.ERROR_CELL, true, isStopped), rowIndex, col++);

--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/streams/StreamsController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/streams/StreamsController.java
@@ -55,8 +55,8 @@ public class StreamsController extends FlowStatsBaseController {
         table.add(new StatisticLabelCell("Tx bps L2", firstColumnWidth, true, CellType.DEFAULT_CELL, false), 0, 2);
         table.add(new StatisticLabelCell("Tx bps L1", firstColumnWidth, false, CellType.DEFAULT_CELL, false), 0, 3);
         table.add(new StatisticLabelCell("Rx pps", firstColumnWidth, true, CellType.DEFAULT_CELL, false), 0, 4);
-        table.add(new StatisticLabelCell("Rx bps L1", firstColumnWidth, false, CellType.DEFAULT_CELL, false), 0, 5);
-        table.add(new StatisticLabelCell("Rx bps L2", firstColumnWidth, true, CellType.DEFAULT_CELL, false), 0, 6);
+        table.add(new StatisticLabelCell("Rx bps L2", firstColumnWidth, false, CellType.DEFAULT_CELL, false), 0, 5);
+        table.add(new StatisticLabelCell("Rx bps L1", firstColumnWidth, true, CellType.DEFAULT_CELL, false), 0, 6);
         table.add(new StatisticLabelCell("Tx pkts", firstColumnWidth, false, CellType.DEFAULT_CELL, false), 0, 7);
         table.add(new StatisticLabelCell("Rx pkts", firstColumnWidth, true, CellType.DEFAULT_CELL, false), 0, 8);
         table.add(new StatisticLabelCell("Tx bytes", firstColumnWidth, false, CellType.DEFAULT_CELL, false), 0, 9);
@@ -101,8 +101,8 @@ public class StreamsController extends FlowStatsBaseController {
                 table.add(new StatisticLabelCell(Util.getFormatted(String.valueOf(round(flowStatPoint.getTbsL2())), true, "b/s"), secondHeaderWidth, true, CellType.DEFAULT_CELL, true, isStopped), rowIndex, 2);
                 table.add(new StatisticLabelCell(Util.getFormatted(String.valueOf(round(flowStatPoint.getTbsL1())), true, "b/s"), secondHeaderWidth, false, CellType.DEFAULT_CELL, true, isStopped), rowIndex, 3);
                 table.add(new StatisticLabelCell(Util.getFormatted(String.valueOf(round(flowStatPoint.getRps())), true, "pkt/s"), secondHeaderWidth, true, CellType.DEFAULT_CELL, true, isStopped), rowIndex, 4);
-                table.add(new StatisticLabelCell(Util.getFormatted(String.valueOf(round(flowStatPoint.getRbsL1())), true, "b/s"), secondHeaderWidth, false, CellType.DEFAULT_CELL, true, isStopped), rowIndex, 5);
-                table.add(new StatisticLabelCell(Util.getFormatted(String.valueOf(round(flowStatPoint.getRbsL2())), true, "b/s"), secondHeaderWidth, true, CellType.DEFAULT_CELL, true, isStopped), rowIndex, 6);
+                table.add(new StatisticLabelCell(Util.getFormatted(String.valueOf(round(flowStatPoint.getRbsL2())), true, "b/s"), secondHeaderWidth, false, CellType.DEFAULT_CELL, true, isStopped), rowIndex, 5);
+                table.add(new StatisticLabelCell(Util.getFormatted(String.valueOf(round(flowStatPoint.getRbsL1())), true, "b/s"), secondHeaderWidth, true, CellType.DEFAULT_CELL, true, isStopped), rowIndex, 6);
                 table.add(new StatisticLabelCell(Util.getFormatted(String.valueOf(tp), true, "pkts"), secondHeaderWidth, false, CellType.DEFAULT_CELL, true, isStopped), rowIndex, 7);
                 table.add(new StatisticLabelCell(Util.getFormatted(String.valueOf(rp), true, "pkts"), secondHeaderWidth, true, CellType.DEFAULT_CELL, true, isStopped), rowIndex, 8);
                 table.add(new StatisticLabelCell(Util.getFormatted(String.valueOf(tb), true, "B"), secondHeaderWidth, false, CellType.DEFAULT_CELL, true, isStopped), rowIndex, 9);

--- a/src/main/java/com/cisco/trex/stl/gui/models/LatencyStatPoint.java
+++ b/src/main/java/com/cisco/trex/stl/gui/models/LatencyStatPoint.java
@@ -1,6 +1,11 @@
 package com.cisco.trex.stl.gui.models;
 
 import com.cisco.trex.stateless.model.stats.LatencyStat;
+import com.cisco.trex.stateless.model.stats.LatencyStatErr;
+import com.cisco.trex.stateless.model.stats.LatencyStatLat;
+
+import java.util.HashMap;
+import java.util.Map;
 
 
 public class LatencyStatPoint {
@@ -18,5 +23,47 @@ public class LatencyStatPoint {
 
     public double getTime() {
         return time;
+    }
+
+    public LatencyStatPoint subtractOffset(LatencyStatPoint offset) {
+        LatencyStat newLatencyStat = subtractLatencyStat(this.latencyStat, offset.latencyStat);
+        return new LatencyStatPoint(newLatencyStat, time);
+    }
+
+    private LatencyStat subtractLatencyStat(LatencyStat stat1, LatencyStat statOffset) {
+        LatencyStatErr newErr = subtractLatencyStatErr(stat1.getErr(), statOffset.getErr());
+        LatencyStatLat newLat = subtractLatencyStatLat(stat1.getLat(), statOffset.getLat());
+
+        LatencyStat result = new LatencyStat();
+        result.setErr(newErr);
+        result.setLat(newLat);
+        return result;
+    }
+
+    private LatencyStatLat subtractLatencyStatLat(LatencyStatLat lat1, LatencyStatLat latOffset) {
+        LatencyStatLat result = new LatencyStatLat();
+        result.setAverage(lat1.getAverage());
+        result.setJit(lat1.getJit());
+        result.setLastMax(lat1.getLastMax());
+        result.setTotalMax(lat1.getTotalMax());
+
+        Map<String, Long> shiftedHistogram = new HashMap<>();
+        lat1.getHistogram().forEach((final String key, final Long value) -> {
+            Long newvalue = value - latOffset.getHistogram().getOrDefault(key, 0L);
+            shiftedHistogram.put(key, newvalue);
+        });
+        result.setHistogram(shiftedHistogram);
+
+        return result;
+    }
+
+    private LatencyStatErr subtractLatencyStatErr(LatencyStatErr err1, LatencyStatErr errOffset) {
+        LatencyStatErr result = new LatencyStatErr();
+        result.setDrp(err1.getDrp() - errOffset.getDrp());
+        result.setDup(err1.getDup() - errOffset.getDup());
+        result.setOoo(err1.getOoo() - errOffset.getOoo());
+        result.setSth(err1.getSth() - errOffset.getSth());
+        result.setStl(err1.getStl() - errOffset.getStl());
+        return result;
     }
 }

--- a/src/main/java/com/exalttech/trex/core/ConnectionManager.java
+++ b/src/main/java/com/exalttech/trex/core/ConnectionManager.java
@@ -425,7 +425,7 @@ public class ConnectionManager {
                         if (res != null) {
                             handleAsyncResponse(res);
                         } else {
-                            error[0] = "Error while verifing the Async request: " + "Async responce is null";
+                            error[0] = "Error while verifing the Async request: " + "No response from server";
                         }
                     } catch (Exception e) {
                         error[0] = "Error while verifing the Async request: " + e.getMessage();

--- a/src/main/java/com/exalttech/trex/core/RPCMethods.java
+++ b/src/main/java/com/exalttech/trex/core/RPCMethods.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.log4j.Logger;
 
+import javax.naming.SizeLimitExceededException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
@@ -84,9 +85,7 @@ public class RPCMethods {
             serverConnectionManager.propagatePortHandler(portID, handler);
             return handler;
 
-        } catch (JsonProcessingException | UnsupportedEncodingException | InvalidRPCResponseException | IncorrectRPCMethodException | NullPointerException ex) {
-            throw new PortAcquireException(ex.getMessage());
-        } catch (IOException ex) {
+        } catch (InvalidRPCResponseException | IncorrectRPCMethodException | NullPointerException | IOException | SizeLimitExceededException ex) {
             throw new PortAcquireException(ex.getMessage());
         }
 
@@ -116,7 +115,7 @@ public class RPCMethods {
         try {
             serverConnectionManager.sendRPCRequest(method, params);
             return true;
-        } catch (JsonProcessingException | UnsupportedEncodingException | InvalidRPCResponseException | IncorrectRPCMethodException ex) {
+        } catch (JsonProcessingException | UnsupportedEncodingException | InvalidRPCResponseException | IncorrectRPCMethodException | SizeLimitExceededException ex) {
             return false;
         }
 
@@ -142,7 +141,7 @@ public class RPCMethods {
             String updateTrafficResponse = serverConnectionManager.sendRPCRequest(Constants.UPDATE_TRAFFIC_METHOD, trafficParams);
             return getMultiplierValue(updateTrafficResponse);
 
-        } catch (JsonProcessingException | UnsupportedEncodingException | InvalidRPCResponseException | IncorrectRPCMethodException | NullPointerException ex) {
+        } catch (JsonProcessingException | UnsupportedEncodingException | InvalidRPCResponseException | IncorrectRPCMethodException | NullPointerException | SizeLimitExceededException ex) {
             throw new TrafficException(ex.toString());
         }
 
@@ -207,7 +206,7 @@ public class RPCMethods {
             LOG.trace("Start Traffic response:" + updateTrafficResponse);
             return getMultiplierValue(updateTrafficResponse);
 
-        } catch (JsonProcessingException | UnsupportedEncodingException | InvalidRPCResponseException | IncorrectRPCMethodException | NullPointerException ex) {
+        } catch (JsonProcessingException | UnsupportedEncodingException | InvalidRPCResponseException | IncorrectRPCMethodException | NullPointerException | SizeLimitExceededException ex) {
             throw new TrafficException(ex.toString());
         }
     }
@@ -381,7 +380,7 @@ public class RPCMethods {
             serverConnectionManager.sendRPCRequest(Constants.PING_METHOD, null);
             LOG.trace("Ping OK");
             return true;
-        } catch (JsonProcessingException | UnsupportedEncodingException | InvalidRPCResponseException | IncorrectRPCMethodException | NullPointerException ex) {
+        } catch (JsonProcessingException | UnsupportedEncodingException | InvalidRPCResponseException | IncorrectRPCMethodException | NullPointerException | SizeLimitExceededException ex) {
             LOG.error("Failed to ping RPC Server", ex);
             return false;
         }

--- a/src/main/java/com/exalttech/trex/remote/models/common/Error.java
+++ b/src/main/java/com/exalttech/trex/remote/models/common/Error.java
@@ -86,6 +86,18 @@ public class Error {
         return specificErr;
     }
 
+    public String getSpecificOrMessage() {
+        if (specificErr != null) {
+            return specificErr;
+        }
+
+        if (message != null) {
+            return message;
+        }
+
+        return "Unknown error from Trex host. No description provided.";
+    }
+
     /**
      *
      * @param specificErr The specific_err

--- a/src/main/java/com/exalttech/trex/ui/views/importPcap/ImportedPacketProperties.java
+++ b/src/main/java/com/exalttech/trex/ui/views/importPcap/ImportedPacketProperties.java
@@ -36,6 +36,8 @@ public class ImportedPacketProperties {
 
     StringProperty countProperty = new SimpleStringProperty("0");
 
+    StringProperty prefixProperty = new SimpleStringProperty("");
+
     /**
      * Get destination enabled property
      *
@@ -232,6 +234,25 @@ public class ImportedPacketProperties {
      */
     public int getCount() {
         return Util.getIntFromString(countProperty.get());
+    }
+
+    /**
+     * Get prefix of stream name property
+     *
+     * @return
+     */
+    public StringProperty getPrefixProperty() {
+        return prefixProperty;
+    }
+
+    /**
+     *
+     * Get prefix string value
+     *
+     * @return
+     */
+    public String getPrefix() {
+        return prefixProperty.get();
     }
 
     /**

--- a/src/main/java/com/exalttech/trex/ui/views/importPcap/ImportedPacketPropertiesView.java
+++ b/src/main/java/com/exalttech/trex/ui/views/importPcap/ImportedPacketPropertiesView.java
@@ -56,6 +56,9 @@ public class ImportedPacketPropertiesView extends AnchorPane {
     @FXML
     TextField countTF;
 
+    @FXML
+    TextField prefixTF;
+
     ImportedPacketProperties propertiesBinder;
 
     /**
@@ -138,6 +141,8 @@ public class ImportedPacketPropertiesView extends AnchorPane {
         ipgRB.selectedProperty().bindBidirectional(propertiesBinder.getIpgSelectionProperty());
 
         countTF.textProperty().bindBidirectional(propertiesBinder.getCountProperty());
+
+        prefixTF.textProperty().bindBidirectional(propertiesBinder.getPrefixProperty());
     }
 
     /**

--- a/src/main/java/com/exalttech/trex/ui/views/importPcap/ImportedPacketTableView.java
+++ b/src/main/java/com/exalttech/trex/ui/views/importPcap/ImportedPacketTableView.java
@@ -35,6 +35,7 @@ import org.pcap4j.core.PcapHandle;
 import org.pcap4j.core.PcapNativeException;
 import org.pcap4j.core.Pcaps;
 import org.pcap4j.packet.Packet;
+import org.testng.util.Strings;
 
 import java.io.EOFException;
 import java.io.File;
@@ -213,7 +214,14 @@ public class ImportedPacketTableView extends AnchorPane {
         tableDataList.clear();
         for (PacketInfo packetInfo : packetInfoList) {
             ImportPcapTableData tableData = new ImportPcapTableData();
-            tableData.setName("packet_" + index);
+
+            StringBuilder name = new StringBuilder();
+            if (!Strings.isNullOrEmpty(propertiesBinder.getPrefix())) {
+                name.append(propertiesBinder.getPrefix()).append("_");
+            }
+            name.append("packet_").append(index);
+
+            tableData.setName(name.toString());
             tableData.setIndex(index);
             tableData.setLength(packetInfo.getPacket().length());
             tableData.setMacSrc(packetInfo.getSrcMac());
@@ -258,8 +266,8 @@ public class ImportedPacketTableView extends AnchorPane {
                         }
                         // update pps/ISG
                         defineISG_PPSValues(profile, getIpg(diffTimeStamp, firstStream));
-                        if (firstStream) {
-                            firstStream = false;
+                        if (!firstStream) {
+                            profile.getStream().setSelfStart(false);
                         }
                         // get next stream 
                         next = getNextSelectedPacket();
@@ -271,6 +279,9 @@ public class ImportedPacketTableView extends AnchorPane {
                             profile.getStream().setActionCount(propertiesBinder.getCount());
                         }
 
+                        if (firstStream) {
+                            firstStream = false;
+                        }
                         current = next;
                         profilesList.add(profile);
                     }

--- a/src/main/java/com/exalttech/trex/ui/views/statistics/StatsTableGenerator.java
+++ b/src/main/java/com/exalttech/trex/ui/views/statistics/StatsTableGenerator.java
@@ -172,7 +172,7 @@ public class StatsTableGenerator {
                     }
                     if (keyBuffer.toString().startsWith("m_total_rx_bps-" + i)) {
                         row_m_rx_bps = key;
-                        stat_value_m_rx_pps = new String(stat_value);
+                        stat_value_m_rx_bps = new String(stat_value);
                     }
                 }
                 if (row_m_tx_bps_l1 != null && row_m_tx_bps != null && row_m_tx_pps != null) {

--- a/src/main/resources/fxml/ImportedPacketPropertiesView.fxml
+++ b/src/main/resources/fxml/ImportedPacketPropertiesView.fxml
@@ -9,9 +9,12 @@
 
 <fx:root prefHeight="480.0" prefWidth="1080.0" type="javafx.scene.layout.AnchorPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
 	<children>
-		<AnchorPane id="AnchorPane" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-			<children>
-				<Label layoutY="8.0" prefHeight="30.0" prefWidth="284.0" styleClass="importedPcapPropertiesNote" text="     Changes will be only applied on IPV4 Packets" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="10.0" />
+        <AnchorPane id="BasicAnchorPane">
+            <Label text="Name prefix" AnchorPane.topAnchor="25" AnchorPane.leftAnchor="30"/>
+            <TextField fx:id="prefixTF" prefHeight="22.0" prefWidth="170.0" AnchorPane.leftAnchor="150.0" AnchorPane.topAnchor="20.0" />
+            <AnchorPane id="AnchorPane" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="60.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+                <children>
+                    <Label layoutY="8.0" prefHeight="30.0" prefWidth="284.0" styleClass="importedPcapPropertiesNote" text="     Changes will be only applied on IPV4 Packets" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="10.0" />
             <Label layoutX="24.0" layoutY="51.0" prefHeight="15.0" prefWidth="284.0" text="Internet Protocol v4" AnchorPane.leftAnchor="30.0" AnchorPane.topAnchor="60.0" />
             <GridPane alignment="CENTER_LEFT" layoutX="34.0" layoutY="74.0" prefHeight="90.0" prefWidth="595.0" AnchorPane.leftAnchor="50.0" AnchorPane.topAnchor="85.0">
               <columnConstraints>
@@ -53,9 +56,10 @@
             <TextField fx:id="speedupTF" layoutX="148.0" layoutY="227.0" prefHeight="22.0" prefWidth="170.0" AnchorPane.leftAnchor="150.0" AnchorPane.topAnchor="247.0" />
             <TextField fx:id="ipgTF" layoutX="130.0" layoutY="257.0" prefHeight="22.0" prefWidth="170.0" AnchorPane.leftAnchor="150.0" AnchorPane.topAnchor="282.0" />
             <Separator layoutX="30.0" layoutY="312.0" prefWidth="650.0" AnchorPane.leftAnchor="30.0" AnchorPane.topAnchor="330.0" />
-            <Label layoutX="56.0" layoutY="328.0" text="Count" AnchorPane.leftAnchor="56.0" AnchorPane.topAnchor="360.0" />
+            <Label layoutX="56.0" layoutY="328.0" text="Loop count" AnchorPane.leftAnchor="56.0" AnchorPane.topAnchor="360.0" />
             <TextField fx:id="countTF" layoutX="130.0" layoutY="316.0" prefHeight="22.0" prefWidth="170.0" AnchorPane.leftAnchor="150.0" AnchorPane.topAnchor="357.0" />
-			</children>
-		</AnchorPane>
-	</children>
+                </children>
+            </AnchorPane>
+        </AnchorPane>
+    </children>
 </fx:root>


### PR DESCRIPTION
- Changed error message on null response from server
- Fixed typo leading to error in Rx L1 Bps stats
- Swaped Rx L1 and L2 rows in streams stas tab, for symmetry with Tx L1 and L2
- Added size check of request which is sending to TRex
- Streams sending to TRex are now sent by groups to fit request size limit
- Added prefix to pcap import dialog to allow import several pcaps in one profile
- Latency stats minor refactoring

### before
![selection_044](https://user-images.githubusercontent.com/35273613/40477751-6cbafcda-5f71-11e8-84c2-4817ff63adcd.png)
### after
![selection_043](https://user-images.githubusercontent.com/35273613/40477750-6c96defe-5f71-11e8-9d21-493c93130218.png)

