### PR TITLE
Fix simple mode without scapy init

### DIFF
--- a/src/main/java/com/exalttech/trex/ui/controllers/PacketBuilderHomeController.java
+++ b/src/main/java/com/exalttech/trex/ui/controllers/PacketBuilderHomeController.java
@@ -193,7 +193,7 @@ public class PacketBuilderHomeController extends DialogView implements Initializ
                 "Scapy server and advanced mode.";
 
         ButtonType tryConnect = new ButtonType("Connect", ButtonBar.ButtonData.YES);
-        ButtonType continueSimple = new ButtonType("Simple Mode");
+        ButtonType continueSimple = new ButtonType("Simple Mode", ButtonBar.ButtonData.NO);
 
         while (true) {
             Optional<ButtonType> userSelection = TrexAlertBuilder.build()
@@ -315,7 +315,7 @@ public class PacketBuilderHomeController extends DialogView implements Initializ
         this.builderDataBinder = builderDataBinder;
         if (!Strings.isNullOrEmpty(packetEditorModel)) {
             packetBuilderController.loadUserModel(packetEditorModel);
-        } else {
+        } else if (getSelectedProfile().getStream().getAdvancedMode()){
             packetBuilderController.loadSimpleUserModel(this.builderDataBinder.serializeAsPacketModel());
         }
         // initialize builder tabs

--- a/src/main/java/com/exalttech/trex/util/TrafficProfile.java
+++ b/src/main/java/com/exalttech/trex/util/TrafficProfile.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.gson.Gson;
 import javafx.stage.Window;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
@@ -191,7 +192,9 @@ public class TrafficProfile {
 
             Map<String, Object> streamAdditionalProperties = profile.getStream().getAdditionalProperties();
             if (streamAdditionalProperties.containsKey("vm")) {
-                profile.getStream().setVmRaw(streamAdditionalProperties.get("vm").toString());
+                Gson gson = new Gson();
+                Object vm = streamAdditionalProperties.get("vm");
+                profile.getStream().setVmRaw(gson.toJson(vm));
             }
             if (streamAdditionalProperties.containsKey("rx_stats")) {
                 profile.getStream().setRxStatsRaw(streamAdditionalProperties.get("rx_stats").toString());


### PR DESCRIPTION
- Fixes Simple mode button, incorrect rendering sometimes
- Fixes Simple mode doesn't work without Scapy (now it works, and it has to work without Scapy)
-  Fixes vmraw ugly format (added quotes, commas etc.)
