### PR TITLE
Redundant rpc fixes

### DIFF
--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/DashboardController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/DashboardController.java
@@ -60,12 +60,10 @@ public class DashboardController extends DialogView implements Initializable {
     @Override
     public void closeHandler() {
         portsManager.removePortServiceModeChangedListener(serviceModeChangeListener);
-        statsStorage.stopPolling();
     }
 
     @Override
     public void showHandler() {
-        statsStorage.startPolling();
         portsManager.addPortServiceModeChangedListener(serviceModeChangeListener);
         handleTabChanged(null);
     }

--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/DashboardController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/DashboardController.java
@@ -6,6 +6,7 @@ import com.cisco.trex.stl.gui.controllers.dashboard.ports.PortsController;
 import com.cisco.trex.stl.gui.controllers.dashboard.streams.StreamsController;
 import com.cisco.trex.stl.gui.controllers.dashboard.utilization.UtilizationController;
 import com.cisco.trex.stl.gui.storages.StatsStorage;
+import com.exalttech.trex.application.TrexApp;
 import com.exalttech.trex.ui.PortsManager;
 import com.exalttech.trex.ui.dialog.DialogView;
 import com.exalttech.trex.ui.models.Port;
@@ -32,6 +33,8 @@ public class DashboardController extends DialogView implements Initializable {
 
     private static final String SERVICE_MODE_ENABLED_LABEL = "Service mode is enabled";
 
+    StatsStorage statsStorage = TrexApp.injector.getInstance(StatsStorage.class);
+
     @FXML
     private TabPane tabPane;
     @FXML
@@ -52,12 +55,19 @@ public class DashboardController extends DialogView implements Initializable {
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
-        portsManager.addPortServiceModeChangedListener(serviceModeChangeListener);
     }
 
     @Override
-    public void shutdown() {
+    public void closeHandler() {
         portsManager.removePortServiceModeChangedListener(serviceModeChangeListener);
+        statsStorage.stopPolling();
+    }
+
+    @Override
+    public void showHandler() {
+        statsStorage.startPolling();
+        portsManager.addPortServiceModeChangedListener(serviceModeChangeListener);
+        handleTabChanged(null);
     }
 
     @Override
@@ -67,56 +77,47 @@ public class DashboardController extends DialogView implements Initializable {
 
     @FXML
     public void handleTabChanged(final Event event) {
+        boolean ports_enabled = false;
+        boolean streams_enabled = false;
+        boolean latency_enabled = false;
+        boolean charts_enabled = false;
+
         switch (tabPane.getSelectionModel().getSelectedItem().getText()) {
-            case UTILIZATION_TAB_LABEL:
-                utilization.setActive(true);
-                ports.setActive(false);
-                streams.setActive(false);
-                latency.setActive(false);
-                charts.setActive(false);
-                break;
             case PORTS_TAB_LABEL:
-                if (utilization != null) {
-                    utilization.setActive(true);
-                }
-                if (ports != null) {
-                    ports.setActive(true);
-                }
-                if (streams != null) {
-                    streams.setActive(false);
-                }
-                if (latency != null) {
-                    latency.setActive(false);
-                }
-                if (charts != null) {
-                    charts.setActive(false);
-                }
+                ports_enabled = true;
                 break;
             case STREAMS_TAB_LABEL:
-                ports.setActive(false);
-                streams.setActive(true);
-                latency.setActive(false);
-                charts.setActive(false);
+                streams_enabled = true;
                 break;
             case LATENCY_TAB_LABEL:
-                ports.setActive(false);
-                streams.setActive(false);
-                latency.setActive(true);
-                charts.setActive(false);
+                latency_enabled = true;
                 break;
             case CHARTS_TAB_LABEL:
-                ports.setActive(false);
-                streams.setActive(false);
-                latency.setActive(false);
-                charts.setActive(true);
+                charts_enabled = true;
                 break;
+        }
+
+        if (utilization != null) {
+            utilization.setActive(true);
+        }
+        if (ports != null) {
+            ports.setActive(ports_enabled);
+        }
+        if (streams != null) {
+            streams.setActive(streams_enabled);
+        }
+        if (latency != null) {
+            latency.setActive(latency_enabled);
+        }
+        if (charts != null) {
+            charts.setActive(charts_enabled);
         }
     }
 
     @FXML
     public void handleClearCacheButtonClicked(final ActionEvent event) {
         StatsLoader.getInstance().reset();
-        StatsStorage.getInstance().getPGIDStatsStorage().reset();
+        statsStorage.getPGIDStatsStorage().reset();
     }
 
     private void serviceModeChanged() {

--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/FlowStatsBaseController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/FlowStatsBaseController.java
@@ -1,5 +1,6 @@
 package com.cisco.trex.stl.gui.controllers.dashboard;
 
+import com.exalttech.trex.application.TrexApp;
 import javafx.scene.layout.AnchorPane;
 
 import com.cisco.trex.stl.gui.storages.PGIDStatsStorage;
@@ -10,6 +11,8 @@ public abstract class FlowStatsBaseController extends AnchorPane {
     private boolean isActive = false;
     private PGIDStatsStorage.StatsChangedListener statsChangedListener = this::render;
 
+    StatsStorage statsStorage = TrexApp.injector.getInstance(StatsStorage.class);
+
     public void setActive(final boolean isActive) {
         if (this.isActive == isActive) {
             return;
@@ -17,10 +20,10 @@ public abstract class FlowStatsBaseController extends AnchorPane {
 
         this.isActive = isActive;
         if (this.isActive) {
-            StatsStorage.getInstance().getPGIDStatsStorage().addStatsChangeListener(statsChangedListener);
+            statsStorage.getPGIDStatsStorage().addStatsChangeListener(statsChangedListener);
             render();
         } else {
-            StatsStorage.getInstance().getPGIDStatsStorage().removeStatsChangeListener(statsChangedListener);
+            statsStorage.getPGIDStatsStorage().removeStatsChangeListener(statsChangedListener);
         }
     }
 

--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/charts/LatencyHistogramController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/charts/LatencyHistogramController.java
@@ -1,5 +1,6 @@
 package com.cisco.trex.stl.gui.controllers.dashboard.charts;
 
+import com.exalttech.trex.application.TrexApp;
 import javafx.beans.value.ObservableValue;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
@@ -30,11 +31,11 @@ public class LatencyHistogramController extends FlowChartController {
     @FXML
     private CategoryAxis xAxis;
 
+    StatsStorage statsStorage = TrexApp.injector.getInstance(StatsStorage.class);
+
     public void render() {
         histogram.getData().clear();
         xAxis.setAutoRanging(true);
-
-        final StatsStorage statsStorage = StatsStorage.getInstance();
 
         final Map<Integer, String> selectedPGIDs = statsStorage.getPGIDsStorage().getSelectedPGIds();
 

--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/charts/LatencyLineChartController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/charts/LatencyLineChartController.java
@@ -1,5 +1,6 @@
 package com.cisco.trex.stl.gui.controllers.dashboard.charts;
 
+import com.exalttech.trex.application.TrexApp;
 import javafx.beans.property.IntegerProperty;
 import javafx.scene.chart.XYChart;
 
@@ -15,6 +16,8 @@ import com.exalttech.trex.util.ArrayHistory;
 
 
 public abstract class LatencyLineChartController extends LineFlowChartController {
+    StatsStorage statsStorage = TrexApp.injector.getInstance(StatsStorage.class);
+
     public LatencyLineChartController(final IntegerProperty interval) {
         super(interval);
 
@@ -26,8 +29,6 @@ public abstract class LatencyLineChartController extends LineFlowChartController
     @Override
     protected void render() {
         getChart().getData().clear();
-
-        final StatsStorage statsStorage = StatsStorage.getInstance();
 
         final Map<Integer, String> selectedPGIDs = statsStorage.getPGIDsStorage().getSelectedPGIds();
 

--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/charts/StreamLineChartController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/charts/StreamLineChartController.java
@@ -1,5 +1,6 @@
 package com.cisco.trex.stl.gui.controllers.dashboard.charts;
 
+import com.exalttech.trex.application.TrexApp;
 import javafx.beans.property.IntegerProperty;
 import javafx.scene.chart.XYChart;
 
@@ -16,6 +17,8 @@ import com.exalttech.trex.util.Formatter;
 
 
 public abstract class StreamLineChartController extends LineFlowChartController {
+    StatsStorage statsStorage = TrexApp.injector.getInstance(StatsStorage.class);
+
     public StreamLineChartController(final IntegerProperty interval) {
         super(interval);
     }
@@ -23,8 +26,6 @@ public abstract class StreamLineChartController extends LineFlowChartController 
     @Override
     protected void render() {
         getChart().getData().clear();
-
-        final StatsStorage statsStorage = StatsStorage.getInstance();
 
         final Map<Integer, String> selectedPGIDs = statsStorage.getPGIDsStorage().getSelectedPGIds();
 

--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/global/GlobalStatsController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/global/GlobalStatsController.java
@@ -1,5 +1,6 @@
 package com.cisco.trex.stl.gui.controllers.dashboard.global;
 
+import com.exalttech.trex.application.TrexApp;
 import javafx.fxml.FXML;
 import javafx.scene.layout.AnchorPane;
 import javafx.stage.WindowEvent;
@@ -45,6 +46,8 @@ public class GlobalStatsController extends GlobalStatsBaseController {
     @FXML
     private GlobalStatsPanelController queueFull;
 
+    private StatsStorage statsStorage = TrexApp.injector.getInstance(StatsStorage.class);
+
     public GlobalStatsController() {
         Initialization.initializeFXML(this, "/fxml/dashboard/global/GlobalStats.fxml");
         Initialization.initializeCloseEvent(root, this::onWindowCloseRequest);
@@ -80,14 +83,13 @@ public class GlobalStatsController extends GlobalStatsBaseController {
         dropRate.setValue(Util.getFormatted(currentStatsList.get("m_rx_drop_bps"), true, "b/s"));
         queueFull.setValue(Util.getFormatted(queue, true, "pkts"));
 
-        final PGIDsStorage pgIdStatsStorage = StatsStorage.getInstance().getPGIDsStorage();
+        final PGIDsStorage pgIdStatsStorage = statsStorage.getPGIDsStorage();
         synchronized (pgIdStatsStorage.getDataLock()) {
             totalStream.setValue(String.valueOf(pgIdStatsStorage.getPgIDs().size()));
         }
     }
 
     private void onWindowCloseRequest(WindowEvent window) {
-        setActive(false);
     }
 
     private static String getQueue(Map<String, String> currentStatsList) {

--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/latency/LatencyController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/latency/LatencyController.java
@@ -1,5 +1,6 @@
 package com.cisco.trex.stl.gui.controllers.dashboard.latency;
 
+import com.exalttech.trex.application.TrexApp;
 import javafx.beans.value.ObservableValue;
 import javafx.fxml.FXML;
 import javafx.scene.control.Toggle;
@@ -47,6 +48,8 @@ public class LatencyController extends FlowStatsBaseController {
     private ToggleGroup toggleGroupMode;
     @FXML
     private GridPane table;
+
+    StatsStorage statsStorage = TrexApp.injector.getInstance(StatsStorage.class);
 
     public LatencyController() {
         Initialization.initializeFXML(this, "/fxml/dashboard/latency/Latency.fxml");
@@ -102,7 +105,7 @@ public class LatencyController extends FlowStatsBaseController {
         table.add(new StatisticLabelCell("Jitter", FIRST_COLUMN_WIDTH, hCol%2 == 0, CellType.DEFAULT_CELL, false), 0, hCol++);
         table.add(new StatisticLabelCell("Errors", FIRST_COLUMN_WIDTH, hCol%2 == 0, CellType.DEFAULT_CELL, false), 0, hCol);
 
-        final PGIDStatsStorage pgIDStatsStorage = StatsStorage.getInstance().getPGIDStatsStorage();
+        final PGIDStatsStorage pgIDStatsStorage = statsStorage.getPGIDStatsStorage();
         final Map<Integer, ArrayHistory<FlowStatPoint>> flowStatPointHistoryMap =
                 pgIDStatsStorage.getFlowStatPointHistoryMap();
         final Map<Integer, FlowStatPoint> flowStatPointShadowMap =
@@ -178,7 +181,7 @@ public class LatencyController extends FlowStatsBaseController {
     private void renderHistogram() {
         table.getChildren().clear();
 
-        final PGIDStatsStorage pgIDStatsStorage = StatsStorage.getInstance().getPGIDStatsStorage();
+        final PGIDStatsStorage pgIDStatsStorage = statsStorage.getPGIDStatsStorage();
         final Map<Integer, ArrayHistory<LatencyStatPoint>> latencyStatPointHistoryMap =
                 pgIDStatsStorage.getLatencyStatPointHistoryMap();
         final String[] histogramKeys = pgIDStatsStorage.getHistogramKeys(HISTOGRAM_SIZE);

--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/selectors/streams/StreamsSelectorController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/selectors/streams/StreamsSelectorController.java
@@ -1,6 +1,7 @@
 package com.cisco.trex.stl.gui.controllers.dashboard.selectors.streams;
 
 import com.cisco.trex.stl.gui.storages.PGIDStatsStorage;
+import com.exalttech.trex.application.TrexApp;
 import javafx.event.Event;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
@@ -36,6 +37,8 @@ public class StreamsSelectorController extends GridPane {
     private Map<Integer, String> selectedPGIDs = new HashMap<>();
     private Set<Integer> pgIDs = new HashSet<>();
 
+    StatsStorage statsStorage = TrexApp.injector.getInstance(StatsStorage.class);
+
     public StreamsSelectorController() {
         Initialization.initializeFXML(
                 this,
@@ -49,7 +52,6 @@ public class StreamsSelectorController extends GridPane {
             return;
         }
 
-        final StatsStorage statsStorage = StatsStorage.getInstance();
         final PGIDsStorage pgIdsStorage = statsStorage.getPGIDsStorage();
         final PGIDStatsStorage pgIdStatsStorage = statsStorage.getPGIDStatsStorage();
 
@@ -69,7 +71,6 @@ public class StreamsSelectorController extends GridPane {
     }
 
     private void render() {
-        final StatsStorage statsStorage = StatsStorage.getInstance();
         final PGIDsStorage pgIDStorage = statsStorage.getPGIDsStorage();
         final PGIDStatsStorage pgIdStatsStorage = statsStorage.getPGIDStatsStorage();
         final Set<Integer> pgIDs = new HashSet<>(pgIDStorage.getPgIDs());
@@ -132,11 +133,11 @@ public class StreamsSelectorController extends GridPane {
 
     private void handleStreamDeleteClicked(final Event event) {
         final SelectedStreamController source = (SelectedStreamController) event.getSource();
-        StatsStorage.getInstance().getPGIDsStorage().deselectPGID(source.getPGId());
+        statsStorage.getPGIDsStorage().deselectPGID(source.getPGId());
     }
 
     private void handleStreamAddClicked(final Event event) {
         final StreamController source = (StreamController) event.getSource();
-        StatsStorage.getInstance().getPGIDsStorage().selectPGID(source.getPGId());
+        statsStorage.getPGIDsStorage().selectPGID(source.getPGId());
     }
 }

--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/streams/StreamsController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/streams/StreamsController.java
@@ -5,6 +5,7 @@ import com.cisco.trex.stl.gui.controllers.dashboard.selectors.streams.StreamsSel
 import com.cisco.trex.stl.gui.models.FlowStatPoint;
 import com.cisco.trex.stl.gui.storages.PGIDStatsStorage;
 import com.cisco.trex.stl.gui.storages.StatsStorage;
+import com.exalttech.trex.application.TrexApp;
 import com.exalttech.trex.ui.views.statistics.cells.CellType;
 import com.exalttech.trex.ui.views.statistics.cells.HeaderCell;
 import com.exalttech.trex.ui.views.statistics.cells.StatisticLabelCell;
@@ -27,6 +28,8 @@ public class StreamsController extends FlowStatsBaseController {
     private StreamsSelectorController streamSelector;
     @FXML
     private GridPane table;
+
+    StatsStorage statsStorage = TrexApp.injector.getInstance(StatsStorage.class);
 
     public StreamsController() {
         Initialization.initializeFXML(this, "/fxml/dashboard/streams/Streams.fxml");
@@ -64,7 +67,7 @@ public class StreamsController extends FlowStatsBaseController {
 
         int rowIndex = 1;
 
-        final PGIDStatsStorage pgIDStatsStorage = StatsStorage.getInstance().getPGIDStatsStorage();
+        final PGIDStatsStorage pgIDStatsStorage = statsStorage.getPGIDStatsStorage();
         final Map<Integer, ArrayHistory<FlowStatPoint>> flowStatPointHistoryMap =
                 pgIDStatsStorage.getFlowStatPointHistoryMap();
         final Map<Integer, FlowStatPoint> flowStatPointShadowMap =

--- a/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/utilization/UtilizationController.java
+++ b/src/main/java/com/cisco/trex/stl/gui/controllers/dashboard/utilization/UtilizationController.java
@@ -5,6 +5,7 @@ import com.cisco.trex.stl.gui.models.MemoryUtilizationModel;
 import com.cisco.trex.stl.gui.models.UtilizationCPUModel;
 import com.cisco.trex.stl.gui.storages.StatsStorage;
 import com.cisco.trex.stl.gui.storages.UtilizationStorage;
+import com.exalttech.trex.application.TrexApp;
 import com.exalttech.trex.util.Initialization;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.value.ObservableValue;
@@ -78,6 +79,8 @@ public class UtilizationController extends AnchorPane {
     
     private UtilizationStorage.UtilizationChangedListener utilizationChangedListener = this::render;
 
+    StatsStorage statsStorage = TrexApp.injector.getInstance(StatsStorage.class);
+
     public UtilizationController() {
         Initialization.initializeFXML(this, "/fxml/dashboard/utilization/Utilization.fxml");
         Initialization.initializeCloseEvent(root, this::onWindowCloseRequest);
@@ -102,7 +105,7 @@ public class UtilizationController extends AnchorPane {
         }
 
         this.isActive = isActive;
-        final UtilizationStorage utilizationStorage = StatsStorage.getInstance().getUtilizationStorage();
+        final UtilizationStorage utilizationStorage = statsStorage.getUtilizationStorage();
         if (this.isActive) {
             utilizationStorage.addUtilizationChangedListener(utilizationChangedListener);
             render();
@@ -140,7 +143,7 @@ public class UtilizationController extends AnchorPane {
     }
 
     private void renderCPU() {
-        UtilizationStorage utilizationStorage = StatsStorage.getInstance().getUtilizationStorage();
+        UtilizationStorage utilizationStorage = statsStorage.getUtilizationStorage();
         synchronized (utilizationStorage.getDataLock()) {
             cpuUtilChart.render(utilizationStorage.getCpuUtilizationHistoryMap());
         }
@@ -179,7 +182,7 @@ public class UtilizationController extends AnchorPane {
     }
 
     private void renderMbuf() {
-        UtilizationStorage utilizationStorage = StatsStorage.getInstance().getUtilizationStorage();
+        UtilizationStorage utilizationStorage = statsStorage.getUtilizationStorage();
         synchronized (utilizationStorage.getDataLock()) {
             List<MemoryUtilizationModel> memUtilsModels = utilizationStorage.getMemUtilsModels();
             memoryUtilTable.getItems().clear();

--- a/src/main/java/com/cisco/trex/stl/gui/storages/StatsStorage.java
+++ b/src/main/java/com/cisco/trex/stl/gui/storages/StatsStorage.java
@@ -5,20 +5,11 @@ import java.util.Set;
 
 
 public class StatsStorage {
-    private static StatsStorage instance;
-
-    public static StatsStorage getInstance() {
-        if (instance == null) {
-            instance = new StatsStorage();
-        }
-        return instance;
-    }
-
     private final PGIDsStorage pgIDsStorage = new PGIDsStorage();
     private final PGIDStatsStorage pgIDStatsStorage = new PGIDStatsStorage();
     private final UtilizationStorage utilizationStorage = new UtilizationStorage();
 
-    private StatsStorage() {
+    StatsStorage() {
         pgIDsStorage.addPGIDsChangedListener(this::handleSelectedPGIDsChanged);
     }
 

--- a/src/main/java/com/exalttech/trex/application/guice/StatelessGUIModule.java
+++ b/src/main/java/com/exalttech/trex/application/guice/StatelessGUIModule.java
@@ -1,5 +1,6 @@
 package com.exalttech.trex.application.guice;
 
+import com.cisco.trex.stl.gui.storages.StatsStorage;
 import com.cisco.trex.stl.gui.util.RunningConfiguration;
 import com.exalttech.trex.core.RPCMethods;
 import com.exalttech.trex.ui.views.streams.builder.ProtocolDataView;
@@ -15,5 +16,6 @@ public class StatelessGUIModule extends AbstractModule {
         bind(RPCMethods.class).in(Singleton.class);
         bind(RunningConfiguration.class).in(Singleton.class);
         bind(ProtocolDataView.class).toProvider(ProtocolDataViewProvider.class);
+        bind(StatsStorage.class).in(Singleton.class);
     }
 }

--- a/src/main/java/com/exalttech/trex/ui/controllers/MainViewController.java
+++ b/src/main/java/com/exalttech/trex/ui/controllers/MainViewController.java
@@ -253,6 +253,7 @@ public class MainViewController implements Initializable, EventHandler<KeyEvent>
     private EventBus eventBus;
     private boolean resetAppInProgress;
     private BooleanProperty trafficProfileLoadedProperty = new SimpleBooleanProperty(false);
+    private StatsStorage statsStorage;
 
     @Override
     public void initialize(URL url, ResourceBundle rb) {
@@ -264,6 +265,7 @@ public class MainViewController implements Initializable, EventHandler<KeyEvent>
         initializeInlineComponent();
         logsContainer.setDisable(false);
         eventBus = TrexApp.injector.getInstance(EventBus.class);
+        statsStorage = TrexApp.injector.getInstance(StatsStorage.class);
         portView.visibleProperty().bind(portViewVisibilityProperty);
         statTableContainer.visibleProperty().bindBidirectional(systemInfoVisibilityProperty);
 
@@ -351,6 +353,7 @@ public class MainViewController implements Initializable, EventHandler<KeyEvent>
 
                 loadSystemInfo();
                 StatsLoader.getInstance().start();
+                statsStorage.startPolling();
                 portManager.updatePortForce();
 
                 serverStatusLabel.setText("Connected");
@@ -592,6 +595,7 @@ public class MainViewController implements Initializable, EventHandler<KeyEvent>
             portManager.clearPorts();
             Platform.runLater(() -> {
                 DialogManager.getInstance().closeAll();
+                statsStorage.stopPolling();
                 shutdownRunningServices();
                 LogsController.getInstance().getView().clear();
 

--- a/src/main/java/com/exalttech/trex/ui/controllers/MainViewController.java
+++ b/src/main/java/com/exalttech/trex/ui/controllers/MainViewController.java
@@ -219,6 +219,7 @@ public class MainViewController implements Initializable, EventHandler<KeyEvent>
     private DialogWindow aboutWindow;
     private DialogWindow captureWindow;
     private DialogWindow preferencesWindow;
+    private DialogWindow dashboardWindow;
 
     private SystemInfoReq systemInfoReq = null;
     private PacketTableView tableView;
@@ -350,7 +351,6 @@ public class MainViewController implements Initializable, EventHandler<KeyEvent>
 
                 loadSystemInfo();
                 StatsLoader.getInstance().start();
-                StatsStorage.getInstance().startPolling();
                 portManager.updatePortForce();
 
                 serverStatusLabel.setText("Connected");
@@ -592,7 +592,6 @@ public class MainViewController implements Initializable, EventHandler<KeyEvent>
             portManager.clearPorts();
             Platform.runLater(() -> {
                 DialogManager.getInstance().closeAll();
-                StatsStorage.getInstance().stopPolling();
                 shutdownRunningServices();
                 LogsController.getInstance().getView().clear();
 
@@ -1065,8 +1064,8 @@ public class MainViewController implements Initializable, EventHandler<KeyEvent>
      */
     private void openStateDialog() {
         try {
-            if (DialogManager.getInstance().getNumberOfOpenedDialog() < 4) {
-                DialogWindow dashboardWindow = new DialogWindow(
+            if (dashboardWindow == null) {
+                dashboardWindow = new DialogWindow(
                         "dashboard/Dashboard.fxml",
                         "Dashboard",
                         50,
@@ -1076,8 +1075,8 @@ public class MainViewController implements Initializable, EventHandler<KeyEvent>
                         true,
                         TrexApp.getPrimaryStage()
                 );
-                dashboardWindow.show(false);
             }
+            dashboardWindow.show(false);
         } catch (IOException ex) {
             LOG.error("Error opening dashboard view", ex);
         }

--- a/src/main/java/com/exalttech/trex/ui/controllers/ports/PortView.java
+++ b/src/main/java/com/exalttech/trex/ui/controllers/ports/PortView.java
@@ -29,6 +29,11 @@ public class PortView extends TabPane {
                 hardwareCounters.stopPolling();
             }
         });
+        visibleProperty().addListener((observable, prevVisible, visible) -> {
+            if (!visible) {
+                hardwareCounters.stopPolling();
+            }
+        });
     }
 
     public void loadModel(PortModel model) {

--- a/src/main/java/com/exalttech/trex/ui/controllers/ports/tabs/PortHardwareCounters.java
+++ b/src/main/java/com/exalttech/trex/ui/controllers/ports/tabs/PortHardwareCounters.java
@@ -42,6 +42,8 @@ public class PortHardwareCounters extends BorderPane {
     private final StatsTableGenerator statsTableGenerator;
     
     private PortsManager portManager;
+
+    private String savedXStatsNames = null;
     
     public PortHardwareCounters() {
         Initialization.initializeFXML(this, "/fxml/ports/PortHardwareCounters.fxml");
@@ -69,9 +71,11 @@ public class PortHardwareCounters extends BorderPane {
     
     private void update() {
         try {
-            String xStatsNames = ConnectionManager.getInstance().sendPortXStatsNamesRequest(port);
+            if (savedXStatsNames == null) {
+                savedXStatsNames = ConnectionManager.getInstance().sendPortXStatsNamesRequest(port);
+            }
             String xStatsValues = ConnectionManager.getInstance().sendPortXStatsValuesRequest(port);
-            Map<String, Long> loadedXStatsList = Util.getXStatsFromJSONString(xStatsNames, xStatsValues);
+            Map<String, Long> loadedXStatsList = Util.getXStatsFromJSONString(savedXStatsNames, xStatsValues);
             port.setXstats(loadedXStatsList);
             Pane pane = statsTableGenerator.generateXStatPane(true, port, statXTableNotEmpty.isSelected(), statXTableFilter.getText(), resetCountersRequested);
             statXTableContainer.setContent(pane);
@@ -90,5 +94,6 @@ public class PortHardwareCounters extends BorderPane {
 
     public void stopPolling() {
         refreshingService.cancel();
+        savedXStatsNames = null;
     } 
 }

--- a/src/main/java/com/exalttech/trex/ui/dialog/DialogView.java
+++ b/src/main/java/com/exalttech/trex/ui/dialog/DialogView.java
@@ -55,5 +55,6 @@ public abstract class DialogView implements DialogKeyPressHandler {
     }
 
 
-    public void shutdown() {}
+    public void closeHandler() {}
+    public void showHandler() {}
 }

--- a/src/main/java/com/exalttech/trex/ui/dialog/DialogWindow.java
+++ b/src/main/java/com/exalttech/trex/ui/dialog/DialogWindow.java
@@ -56,12 +56,13 @@ public class DialogWindow {
 
         dialogStage.setOnCloseRequest(event -> {
             DialogManager.getInstance().removeHandler(this);
-            ((DialogView) loader.getController()).shutdown();
+            ((DialogView) loader.getController()).closeHandler();
         });
         dialogStage.setOnHidden( event -> {
             DialogManager.getInstance().removeHandler(this);
         });
         dialogStage.setOnShowing(event -> {
+            ((DialogView) loader.getController()).showHandler();
             DialogManager.getInstance().addHandler(this, () -> dialogStage.close());
         });
     }

--- a/src/main/java/com/exalttech/trex/ui/views/statistics/StatsTableGenerator.java
+++ b/src/main/java/com/exalttech/trex/ui/views/statistics/StatsTableGenerator.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  *
@@ -45,13 +44,13 @@ public class StatsTableGenerator {
     Map<String, String> currentStatsList;
     Map<String, String> cachedStatsList;
     Map<String, String> prevStatsList;
-    Map<String, Long> totalValues = new HashMap<>();
-    Map<String, Long> prevTotalValues = new HashMap<>();
+    Map<String, Long> totalValues;
+    Map<String, Long> prevTotalValues;
 
-    GridPane statTable = new GridPane();
-    GridPane statXTable = new GridPane();
+    GridPane statTable;
+    GridPane statXTable;
 
-    Map<String, StatisticCell> gridCellsMap = new HashMap<>();
+    Map<String, StatisticCell> gridCellsMap;
     StringBuilder keyBuffer = new StringBuilder(30);
 
     private boolean odd;
@@ -67,6 +66,10 @@ public class StatsTableGenerator {
      * Constructor
      */
     public StatsTableGenerator() {
+        init();
+    }
+
+    private void init() {
         statTable = new GridPane();
         statTable.setCache(false);
         statTable.getStyleClass().add("statsTable");
@@ -76,6 +79,10 @@ public class StatsTableGenerator {
         statXTable.setCache(false);
         statXTable.getStyleClass().add("statsTable");
         statXTable.setGridLinesVisible(false);
+
+        totalValues = new HashMap<>();
+        prevTotalValues = new HashMap<>();
+        gridCellsMap = new HashMap<>();
     }
 
     /**
@@ -598,9 +605,11 @@ public class StatsTableGenerator {
     public void reset() {
 
         statTable.getChildren().clear();
+        statXTable.getChildren().clear();
         Util.optimizeMemory();
 
         statTable = null;
+        statXTable = null;
 
         gridCellsMap.clear();
         gridCellsMap = null;
@@ -626,6 +635,8 @@ public class StatsTableGenerator {
 
         prevTotalValues.clear();
         prevStatsList = null;
+
+        init();
     }
 
     /**


### PR DESCRIPTION
Redundant RPC optimization

- Removed xstats polling, if xstats tab is not visible
- Added caching of xStatsNames
- Fixed multiple Dashboard windows possible (now, only one Dashboard is possible to open)
- Polling of DashboardStats still starts on connection, and stops on disconnect (to collect whole statistics)
- Changed StatsStorage singleton implementation to Guice module (StatelessGUIModule), implemented as injection (could be used for testing later)