### PR TITLE
Native profile imports and Stream rename

### DIFF
--- a/src/main/java/com/exalttech/trex/ui/controllers/PacketBuilderHomeController.java
+++ b/src/main/java/com/exalttech/trex/ui/controllers/PacketBuilderHomeController.java
@@ -173,7 +173,7 @@ public class PacketBuilderHomeController extends DialogView implements Initializ
      * if Scapy is not connected, user decides either switch to Simple mode,
      * or to try to connect or to cancel editing.
      * In case of Simple mode selected by user, stream by profileIndex is switched to Simple mode
-     * @return
+     * @return true if user selects Simple or Advanced mode, false if user cancels
      */
     private boolean prepareToAdvancedIfNecessary(int profileIndex) {
         Stream stream = this.profileList.get(profileIndex).getStream();

--- a/src/main/java/com/exalttech/trex/ui/controllers/ProfileStreamNameDialogController.java
+++ b/src/main/java/com/exalttech/trex/ui/controllers/ProfileStreamNameDialogController.java
@@ -182,4 +182,7 @@ public class ProfileStreamNameDialogController extends DialogView implements Ini
         doCreating(stage);
     }
 
+    public void setDefaultName(String defaultName) {
+        nameTF.setText(defaultName);
+    }
 }

--- a/src/main/java/com/exalttech/trex/ui/controllers/TrafficProfileDialogController.java
+++ b/src/main/java/com/exalttech/trex/ui/controllers/TrafficProfileDialogController.java
@@ -376,6 +376,5 @@ public class TrafficProfileDialogController extends DialogView implements Initia
      */
     @Override
     public void onEnterKeyPressed(Stage stage) {
-        stage.hide();
     }
 }

--- a/src/main/java/com/exalttech/trex/ui/controllers/TrafficProfileDialogController.java
+++ b/src/main/java/com/exalttech/trex/ui/controllers/TrafficProfileDialogController.java
@@ -377,4 +377,12 @@ public class TrafficProfileDialogController extends DialogView implements Initia
     @Override
     public void onEnterKeyPressed(Stage stage) {
     }
+
+
+    @Override
+    public void onEscapKeyPressed() {
+        if (!tableView.isEditingCell()) {
+            super.onEscapKeyPressed();
+        }
+    }
 }

--- a/src/main/java/com/exalttech/trex/ui/dialog/DialogWindow.java
+++ b/src/main/java/com/exalttech/trex/ui/dialog/DialogWindow.java
@@ -132,4 +132,8 @@ public class DialogWindow {
     public boolean isVisible() {
         return dialogStage.isShowing();
     }
+
+    public void setTitle(String windowTitle) {
+        dialogStage.setTitle(windowTitle);
+    }
 }

--- a/src/main/java/com/exalttech/trex/ui/views/CallbackEditCell.java
+++ b/src/main/java/com/exalttech/trex/ui/views/CallbackEditCell.java
@@ -1,0 +1,33 @@
+package com.exalttech.trex.ui.views;
+
+import javafx.scene.control.cell.TextFieldTableCell;
+import javafx.util.StringConverter;
+
+public class CallbackEditCell<S, T> extends TextFieldTableCell<S, T> {
+    private final CallbackEditHandler<T> handler;
+
+    @FunctionalInterface
+    interface CallbackEditHandler<T> {
+        /**
+         * Callback which is called right before commitEdit of cell
+         * @param rowIndex index of row to be edited
+         * @param newValue new value to received on commitEdit
+         * @return true if success, false otherwise. If returns true, TextFieldTableCell commits newValue,
+         * if false -- does not commit.
+         */
+        boolean update(Integer rowIndex, T newValue);
+    }
+
+    public CallbackEditCell(CallbackEditHandler<T> handler, StringConverter<T> converter) {
+        super(converter);
+        this.handler = handler;
+    }
+
+    @Override
+    public void commitEdit(T newValue) {
+        boolean isSuccess = handler.update(getIndex(), newValue);
+        if (isSuccess) {
+            super.commitEdit(newValue);
+        }
+    }
+}

--- a/src/main/java/com/exalttech/trex/ui/views/PacketTableView.java
+++ b/src/main/java/com/exalttech/trex/ui/views/PacketTableView.java
@@ -472,19 +472,10 @@ public class PacketTableView extends AnchorPane implements EventHandler<ActionEv
     private void duplicateProfiles(List<Profile> newProfiles) {
         try{
             List<Profile> profiles = tabledata.getProfiles();
-
             for (Profile profile : newProfiles) {
                 String defaultDuplicateName = getNameOfDuplicate(profile.getName(), profiles);
-                if (defaultDuplicateName.equals(profile.getName())) {
-                    cloneProfile(profiles, profile, defaultDuplicateName);
-                } else {
-                    Optional<String> userEnteredName = askUserToEnterStreamName("Duplicate stream (" + profile.getName() + ")", defaultDuplicateName);
-                    if (userEnteredName.isPresent()) {
-                        cloneProfile(profiles, profile, userEnteredName.get());
-                    }
-                }
+                cloneProfile(profiles, profile, defaultDuplicateName);
             }
-
             refreshTableFromTableData();
         } catch (CloneNotSupportedException | IOException ex) {
             LOG.error("Error duplicating streams", ex);

--- a/src/main/java/com/exalttech/trex/ui/views/PacketTableView.java
+++ b/src/main/java/com/exalttech/trex/ui/views/PacketTableView.java
@@ -104,7 +104,7 @@ public class PacketTableView extends AnchorPane implements EventHandler<ActionEv
     private boolean doUpdate = false;
     ContextMenu rightClickMenu;
     private File loadedProfile;
-    private DialogWindow srteamWindow;
+    private DialogWindow streamWindow;
 
     /**
      * @param maxHight
@@ -651,12 +651,14 @@ public class PacketTableView extends AnchorPane implements EventHandler<ActionEv
                 return;
             }
             setStreamEditingWindowOpen(true);
-            if (srteamWindow == null) {
+            String windowTitle = "Edit Stream (" + data.getName() + ")";
+            if (streamWindow == null) {
                 Stage currentStage = (Stage) streamPacketTableView.getScene().getWindow();
-                String windowTitle = "Edit Stream (" + data.getName() + ")";
-                srteamWindow = new DialogWindow("PacketBuilderHome.fxml", windowTitle, 40, 30, false, currentStage);
+                streamWindow = new DialogWindow("PacketBuilderHome.fxml", windowTitle, 40, 30, false, currentStage);
             }
-            PacketBuilderHomeController controller = (PacketBuilderHomeController) srteamWindow.getController();
+            streamWindow.setTitle(windowTitle);
+
+            PacketBuilderHomeController controller = (PacketBuilderHomeController) streamWindow.getController();
 
             boolean streaminited = controller.initStreamBuilder(
                     tabledata.getProfiles(),
@@ -666,7 +668,7 @@ public class PacketTableView extends AnchorPane implements EventHandler<ActionEv
             );
 
             if (streaminited) {
-                srteamWindow.show(true);
+                streamWindow.show(true);
             }
             else {
                 LOG.error("Error while initing editor dialog");

--- a/src/main/java/com/exalttech/trex/ui/views/PacketTableView.java
+++ b/src/main/java/com/exalttech/trex/ui/views/PacketTableView.java
@@ -65,11 +65,9 @@ import org.pcap4j.packet.namednumber.DataLinkType;
 import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collector;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -80,6 +78,7 @@ import java.util.stream.Collectors;
 public class PacketTableView extends AnchorPane implements EventHandler<ActionEvent>, CheckBoxTableChangeHandler {
 
     private static final Logger LOG = Logger.getLogger(PacketTableView.class.getName());
+    public static final String NUMERATED_PROFILE_REGEX_PATTERN = "(?<baseName>.+?)(?<index>[0-9]+)?$";
 
     StreamTableButton buildPacketBtn;
     StreamTableButton editPacketBtn;
@@ -106,7 +105,6 @@ public class PacketTableView extends AnchorPane implements EventHandler<ActionEv
     ContextMenu rightClickMenu;
     private File loadedProfile;
     private DialogWindow srteamWindow;
-    private DialogWindow profileNameWindow;
 
     /**
      * @param maxHight
@@ -408,17 +406,40 @@ public class PacketTableView extends AnchorPane implements EventHandler<ActionEv
         return selectedProfiles;
     }
 
-    private String getNewName(String profileName, List<Profile> profiles) {
+    /**
+     * Gets default name for the specified with {@literal profileName}
+     * Tries to match regexp and to increment number if it matches, otherwise adds suffix
+     *
+     * regexp {@value NUMERATED_PROFILE_REGEX_PATTERN} matches these number suffix: <br>
+     * myProfile<b>1</b> <br>
+     * myProfile_<b>1234234</b> <br>
+     * myProfile_<b>1234</b> <br>
+     *
+     * @param profileName name of original profile
+     * @param profiles list of existing profiles (to avoid names collision)
+     */
+    private String getNameOfDuplicate(String profileName, List<Profile> profiles) {
         Set<String> profileNames = profiles.stream()
                 .map(Profile::getName)
                 .collect(Collectors.toSet());
 
+        Pattern profileWithIndexPattern = Pattern.compile(NUMERATED_PROFILE_REGEX_PATTERN);
+        Matcher matcher = profileWithIndexPattern.matcher(profileName);
+
         int availableSuffix = 1;
-        while (profileNames.contains(profileName + "_" + availableSuffix)) {
-            ++availableSuffix;
+        String baseProfileName = profileName;
+
+        if (matcher.find()) {
+            if (matcher.groupCount() == 2 && !Util.isNullOrEmpty(matcher.group("index"))) {
+                availableSuffix = Integer.parseInt(matcher.group("index"));
+            }
+            baseProfileName = matcher.group("baseName");
         }
 
-        return profileName + "_" + availableSuffix;
+        while (profileNames.contains(baseProfileName + availableSuffix)) {
+            ++availableSuffix;
+        }
+        return baseProfileName + availableSuffix;
     }
 
     private Integer getNewId() {
@@ -440,10 +461,16 @@ public class PacketTableView extends AnchorPane implements EventHandler<ActionEv
             List<Profile> profiles = tabledata.getProfiles();
 
             for (Profile profile : newProfiles) {
-                Profile clonedProfile = (Profile) profile.clone();
-                clonedProfile.setName(getNewName(profile.getName(), profiles));
-                clonedProfile.setStreamId(getNewId());
-                profiles.add(clonedProfile);
+                String defaultDuplicateName = getNameOfDuplicate(profile.getName(), profiles);
+                Optional<String> userEnteredName = askUserToEnterStreamName("Duplicate stream", defaultDuplicateName);
+                if (userEnteredName.isPresent()) {
+                    Profile clonedProfile = (Profile) profile.clone();
+
+                    clonedProfile.setName(userEnteredName.get());
+                    clonedProfile.setStreamId(getNewId());
+                    profiles.add(clonedProfile);
+                }
+
             }
 
             Profile[] newProfileDataList = tabledata.getProfiles().toArray(new Profile[tabledata.getProfiles().size()]);
@@ -664,22 +691,41 @@ public class PacketTableView extends AnchorPane implements EventHandler<ActionEv
      */
     private void viewStreamNameWindow(StreamBuilderType type) {
         try {
-            if(profileNameWindow == null) {
-                Stage currentStage = (Stage) streamPacketTableView.getScene().getWindow();
-                profileNameWindow = new DialogWindow("ProfileStreamNameDialog.fxml", "Add Stream", 150, 100, false, currentStage);
-            }
-            ProfileStreamNameDialogController controller = (ProfileStreamNameDialogController) profileNameWindow.getController();
-            controller.setProfileList(tabledata.getProfiles());
-            controller.setProfileWindow(false);
-            profileNameWindow.show(true);
-            if (controller.isDataAvailable()) {
-                String streamName = controller.getName();
-                handleAddPacket(streamName, type);
-            }
-
+            Optional<String> newStreamName = askUserToEnterStreamName("Add stream", "");
+            newStreamName.ifPresent(name -> {
+                handleAddPacket(name, type);
+            });
         } catch (IOException ex) {
             LOG.error("Error adding new stream", ex);
         }
+    }
+
+    /**
+     * Ask user to enter stream name
+     *
+     * @param dialogTitle
+     * @param defaultName
+     */
+    private Optional<String> askUserToEnterStreamName(String dialogTitle, String defaultName) throws IOException {
+        Stage currentStage = (Stage) streamPacketTableView.getScene().getWindow();
+        DialogWindow profileNameWindow = new DialogWindow("ProfileStreamNameDialog.fxml",
+                dialogTitle,
+                150,
+                100,
+                false,
+                currentStage
+        );
+        ProfileStreamNameDialogController controller = (ProfileStreamNameDialogController) profileNameWindow.getController();
+        controller.setProfileList(tabledata.getProfiles());
+        controller.setDefaultName(defaultName);
+        controller.setProfileWindow(false);
+        profileNameWindow.show(true);
+
+        if (controller.isDataAvailable()) {
+            return Optional.ofNullable(controller.getName());
+        }
+
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/com/exalttech/trex/util/ProfileManager.java
+++ b/src/main/java/com/exalttech/trex/util/ProfileManager.java
@@ -38,7 +38,6 @@ import javafx.stage.Stage;
 public class ProfileManager {
 
     private static ProfileManager instance = null;
-    private DialogWindow profileNameWindow;
 
     /**
      * Return instance of the saveLoadProfiles
@@ -172,15 +171,15 @@ public class ProfileManager {
     }
 
     private String getProfileNameDialogValue(Stage currentStage, String title) throws IOException {
-        if (profileNameWindow == null) {
-            profileNameWindow = new DialogWindow(
-                    "ProfileStreamNameDialog.fxml",
-                    title,
-                    150,
-                    100,
-                    false,
-                    currentStage);
-        }
+        DialogWindow profileNameWindow = new DialogWindow(
+                "ProfileStreamNameDialog.fxml",
+                title,
+                150,
+                100,
+                false,
+                currentStage
+        );
+
         ProfileStreamNameDialogController controller = (ProfileStreamNameDialogController) profileNameWindow.getController();
         controller.setProfileWindow(true);
         profileNameWindow.show(true);

--- a/src/test/java/com/exalttech/trex/util/TrafficProfileTest.java
+++ b/src/test/java/com/exalttech/trex/util/TrafficProfileTest.java
@@ -1,0 +1,109 @@
+package com.exalttech.trex.util;
+
+import com.exalttech.trex.application.TrexApp;
+import com.exalttech.trex.remote.models.profiles.Profile;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.inject.Guice;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.*;
+
+public class TrafficProfileTest {
+
+    private TrafficProfile trafficProfile;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private File getYaml(String yamlFileName) {
+        ClassLoader classLoader = getClass().getClassLoader();
+        return new File(classLoader.getResource(yamlFileName).getFile());
+    }
+
+    @Before
+    public void setUp() {
+        trafficProfile = new TrafficProfile();
+    }
+
+    @Test
+    public void getTrafficProfile_GuiProfiles() throws IOException {
+        File yamlFile = getYaml("yamls/Profile_burst_two_streams_chain.yaml");
+
+        Profile[] parsedProfiles = this.trafficProfile.getTrafficProfile(yamlFile);
+
+        assertEquals(2, parsedProfiles.length);
+        assertEquals("burst", parsedProfiles[0].getName());
+        assertEquals("burst2", parsedProfiles[0].getNext());
+
+        assertEquals("burst2", parsedProfiles[1].getName());
+        assertEquals("-1", parsedProfiles[1].getNext());
+
+        String expectedVmRaw = "{\"split_by_var\":\"\",\"instructions\":[],\"cache_size\":5000}";
+        assertEquals(expectedVmRaw, parsedProfiles[0].getStream().getVmRaw());
+        assertEquals(expectedVmRaw, parsedProfiles[1].getStream().getVmRaw());
+    }
+
+    @Test
+    public void getTrafficProfile_NativeStreams() throws IOException {
+        File yamlFile = getYaml("yamls/Native_burst_three_streams_chain.yaml");
+
+        Profile[] parsedProfiles = this.trafficProfile.getTrafficProfile(yamlFile);
+
+        assertEquals(3, parsedProfiles.length);
+        assertEquals("S0", parsedProfiles[0].getName());
+        assertEquals("S1", parsedProfiles[0].getNext());
+
+        assertEquals("S1", parsedProfiles[1].getName());
+        assertEquals("S2", parsedProfiles[1].getNext());
+
+        assertEquals("S2", parsedProfiles[2].getName());
+        assertEquals("-1", parsedProfiles[2].getNext());
+
+        String expectedVmRaw = "{\"instructions\":[]}";
+
+        for (Profile p : parsedProfiles) {
+            assertEquals(p.getStream().getVmRaw(), expectedVmRaw);
+        }
+    }
+
+    @Test
+    public void getTrafficProfile_NativeStreamsNoNames() throws IOException {
+        File yamlFile = getYaml("yamls/Native_burst_three_streams_chain_no_names.yaml");
+
+        Profile[] parsedProfiles = this.trafficProfile.getTrafficProfile(yamlFile);
+
+        assertEquals(3, parsedProfiles.length);
+        assertEquals("Stream_0", parsedProfiles[0].getName());
+        assertEquals("Stream_1", parsedProfiles[1].getName());
+        assertEquals("Stream_2", parsedProfiles[2].getName());
+    }
+
+    @Test
+    public void getTrafficProfile_validProfiles() {
+        Stream<File> validYamls = Stream.of("yamls/simpleTcpProfile.yaml", "yamls/simpleUdpStream.yaml").map(this::getYaml);
+
+        validYamls.forEach(yamlFile -> {
+            try {
+                Profile[] parsedProfiles = this.trafficProfile.getTrafficProfile(yamlFile);
+            } catch (IOException e) {
+                fail();
+            }
+        });
+    }
+
+    @Test
+    public void getTrafficProfile_invalidProfile() throws IOException {
+        File invalidYaml = getYaml("yamls/invalid.yaml");
+
+        expectedException.expect(IOException.class);
+        Profile[] parsedProfile = this.trafficProfile.getTrafficProfile(invalidYaml);
+    }
+}

--- a/src/test/resources/yamls/Native_burst_three_streams_chain.yaml
+++ b/src/test/resources/yamls/Native_burst_three_streams_chain.yaml
@@ -1,0 +1,63 @@
+- action_count: 0
+  enabled: true
+  flags: 0
+  flow_stats:
+    enabled: false
+  isg: 10.0
+  mode:
+    rate:
+      type: pps
+      value: 10
+    total_pkts: 10000
+    type: single_burst
+  name: S0
+  next: S1
+  packet:
+    binary: !!python/unicode 'AAAAAQAAAAAAAgAACABFAAAuAAEAAEAROr0QAAABMAAAAQQBAAwAGn9veHh4eHh4eHh4eHh4eHh4eHh4'
+    meta: ''
+  self_start: true
+  start_paused: false
+  vm:
+    instructions: []
+- action_count: 0
+  enabled: true
+  flags: 0
+  flow_stats:
+    enabled: false
+  isg: 0.0
+  mode:
+    rate:
+      type: pps
+      value: 10
+    total_pkts: 10000
+    type: single_burst
+  name: S1
+  next: S2
+  packet:
+    binary: !!python/unicode 'AAAAAQAAAAAAAgAACABFAAAuAAEAAEAROrwQAAACMAAAAQQBAAwAGn9ueHh4eHh4eHh4eHh4eHh4eHh4'
+    meta: ''
+  self_start: false
+  start_paused: false
+  vm:
+    instructions: []
+- action_count: 0
+  enabled: true
+  flags: 0
+  flow_stats:
+    enabled: false
+  isg: 0.0
+  mode:
+    rate:
+      type: pps
+      value: 10
+    total_pkts: 10000
+    type: single_burst
+  name: S2
+  packet:
+    binary: !!python/unicode 'AAAAAQAAAAAAAgAACABFAAAuAAEAAEAROrsQAAADMAAAAQQBAAwAGn9teHh4eHh4eHh4eHh4eHh4eHh4'
+    meta: ''
+  self_start: false
+  start_paused: false
+  vm:
+    instructions: []
+

--- a/src/test/resources/yamls/Native_burst_three_streams_chain_no_names.yaml
+++ b/src/test/resources/yamls/Native_burst_three_streams_chain_no_names.yaml
@@ -1,0 +1,46 @@
+- action_count: 0
+  enabled: true
+  flags: 0
+  isg: 10.0
+  mode:
+    rate:
+      type: pps
+      value: 10
+    total_pkts: 10000
+    type: single_burst
+  packet:
+    binary: !!python/unicode 'AAAAAQAAAAAAAgAACABFAAAuAAEAAEAROr0QAAABMAAAAQQBAAwAGn9veHh4eHh4eHh4eHh4eHh4eHh4'
+    meta: ''
+  self_start: true
+  start_paused: false
+- action_count: 0
+  enabled: true
+  flags: 0
+  isg: 0.0
+  mode:
+    rate:
+      type: pps
+      value: 10
+    total_pkts: 10000
+    type: single_burst
+  packet:
+    binary: !!python/unicode 'AAAAAQAAAAAAAgAACABFAAAuAAEAAEAROrwQAAACMAAAAQQBAAwAGn9ueHh4eHh4eHh4eHh4eHh4eHh4'
+    meta: ''
+  self_start: false
+  start_paused: false
+- action_count: 0
+  enabled: true
+  flags: 0
+  isg: 0.0
+  mode:
+    rate:
+      type: pps
+      value: 10
+    total_pkts: 10000
+    type: single_burst
+  packet:
+    binary: !!python/unicode 'AAAAAQAAAAAAAgAACABFAAAuAAEAAEAROrsQAAADMAAAAQQBAAwAGn9teHh4eHh4eHh4eHh4eHh4eHh4'
+    meta: ''
+  self_start: false
+  start_paused: false
+

--- a/src/test/resources/yamls/Profile_burst_two_streams_chain.yaml
+++ b/src/test/resources/yamls/Profile_burst_two_streams_chain.yaml
@@ -1,0 +1,63 @@
+---
+- name: "burst"
+  next: "burst2"
+  stream:
+    action_count: 0
+    enabled: true
+    flags: 0
+    flow_stats:
+      enabled: false
+      stream_id: 0
+    isg: 0.0
+    mode:
+      rate:
+        type: "pps"
+        value: 1.0
+      type: "single_burst"
+      total_pkts: 1
+      pkts_per_burst: 0
+      ibg: 0.0
+      count: 1
+    
+    packet:
+      binary: "AAAAAAAAAAAAAAAACABFAAAuBNIAAH8G9vYQAAABMAAAAQQBBAEAAff6AAAAAFLABACz4wAAAKoAAAAA"
+      meta: "eyJwcm90b2NvbF9zZWxlY3Rpb24iOnsiaXNfdGFnZ2VkX3ZsYW5fc2VsZWN0ZWQiOmZhbHNlLCJpc19pcHY0X3NlbGVjdGVkIjp0cnVlLCJpc190Y3Bfc2VsZWN0ZWQiOnRydWUsImlzX3VkcF9zZWxlY3RlZCI6ZmFsc2UsImlzX3BhdHRlcm5fc2VsZWN0ZWQiOnRydWUsImZyYW1lX2xlbmd0aF90eXBlIjoiRml4ZWQiLCJmcmFtZV9sZW5ndGgiOiI2NCIsIm1heF9sZW5ndGgiOiIxNTE4IiwibWluX2xlbmd0aCI6IjY0In0sImV0aGVybmV0Ijp7InR5cGUiOiIwODAwIiwiaXNfb3ZlcnJpZGUiOmZhbHNlfSwibWFjIjp7InNvdXJjZSI6eyJjb3VudCI6IjE2IiwibW9kZSI6IlRSZXggQ29uZmlnIiwic3RlcCI6IjEiLCJhZGRyZXNzIjoiMDA6MDA6MDA6MDA6MDA6MDAifSwiZGVzdGluYXRpb24iOnsiY291bnQiOiIxNiIsIm1vZGUiOiJUUmV4IENvbmZpZyIsInN0ZXAiOiIxIiwiYWRkcmVzcyI6IjAwOjAwOjAwOjAwOjAwOjAwIn19LCJpcHY0Ijp7InNvdXJjZSI6eyJjb3VudCI6IjE2IiwibW9kZSI6IkZpeGVkIiwic3RlcCI6IjEiLCJhZGRyZXNzIjoiMTYuMC4wLjEifSwiZGVzdGluYXRpb24iOnsiY291bnQiOiIxNiIsIm1vZGUiOiJGaXhlZCIsInN0ZXAiOiIxIiwiYWRkcmVzcyI6IjQ4LjAuMC4xIn19LCJ0Y3AiOnsiaXNfb3ZlcnJpZGVfZHN0X3BvcnQiOmZhbHNlLCJzcmNfcG9ydCI6IjEwMjUiLCJkc3RfcG9ydCI6IjEwMjUiLCJpc19vdmVycmlkZV9zcmNfcG9ydCI6ZmFsc2UsInNlcXVlbmNlX251bWJlciI6IjEyOTAxOCIsImFja19udW1iZXIiOiIwIiwiaXNfb3ZlcnJpZGVfY2hlY2tzdW0iOmZhbHNlLCJjaGVja3N1bSI6IkIzRTMiLCJ1cmdlbnRfcG9pbnRlciI6IjAiLCJpc191cmciOmZhbHNlLCJpc19hY2siOmZhbHNlLCJpc19wc2giOmZhbHNlLCJpc19yc3QiOmZhbHNlLCJpc19zeW5jIjpmYWxzZSwiaXNfZmluIjpmYWxzZSwid2luZG93IjoiMTAyNCJ9LCJ1ZHAiOnsiaXNfb3ZlcnJpZGVfZHN0X3BvcnQiOmZhbHNlLCJpc19vdmVycmlkZV9sZW5ndGgiOmZhbHNlLCJzcmNfcG9ydCI6IjEwMjUiLCJkc3RfcG9ydCI6IjEwMjUiLCJpc19vdmVycmlkZV9zcmNfcG9ydCI6ZmFsc2UsImlzX292ZXJyaWRlX2NoZWNrc3VtIjpmYWxzZSwiY2hlY2tzdW0iOiJGRkJBIiwibGVuZ3RoIjoiMjYifSwicGF5bG9hZCI6eyJ0eXBlIjoiRml4ZWQgV29yZCIsInBhdHRlcm4iOiIwMCJ9LCJ2bGFuIjp7ImlzX292ZXJyaWRlX3RwX2lkIjpmYWxzZSwidHBfaWQiOiJGRkZGIiwiY2ZpIjoiMCIsInZfaWQiOiIwIiwicHJpb3JpdHkiOiIwIn0sImFkdmFuc2VkX3Byb3BlcnRpZXMiOnsiY2FjaGVfdmFsdWUiOiI1MDAwIiwiY2FjaGVfc2l6ZV90eXBlIjoiQXV0byJ9LCJtb2RlbF92ZXJzaW9uIjoiMS4wIn0="
+      model: ""
+    self_start: true
+    advanced_mode: false
+    vm:
+      split_by_var: ""
+      instructions: []
+      cache_size: 5000
+  stream_id: 0
+- name: "burst2"
+  
+  stream:
+    action_count: 0
+    enabled: true
+    flags: 0
+    flow_stats:
+      enabled: false
+      stream_id: 0
+    isg: 0.0
+    mode:
+      rate:
+        type: "pps"
+        value: 1.0
+      type: "single_burst"
+      total_pkts: 1
+      pkts_per_burst: 0
+      ibg: 0.0
+      count: 1
+    
+    packet:
+      binary: "AAAAAAAAAAAAAAAACABFAAAuBNIAAH8G9vYQAAABMAAAAQQBBAEAAff6AAAAAFLABACz4wAAAKoAAAAA"
+      meta: "eyJwcm90b2NvbF9zZWxlY3Rpb24iOnsiaXNfdGFnZ2VkX3ZsYW5fc2VsZWN0ZWQiOmZhbHNlLCJpc19pcHY0X3NlbGVjdGVkIjp0cnVlLCJpc190Y3Bfc2VsZWN0ZWQiOnRydWUsImlzX3VkcF9zZWxlY3RlZCI6ZmFsc2UsImlzX3BhdHRlcm5fc2VsZWN0ZWQiOnRydWUsImZyYW1lX2xlbmd0aF90eXBlIjoiRml4ZWQiLCJmcmFtZV9sZW5ndGgiOiI2NCIsIm1heF9sZW5ndGgiOiIxNTE4IiwibWluX2xlbmd0aCI6IjY0In0sImV0aGVybmV0Ijp7InR5cGUiOiIwODAwIiwiaXNfb3ZlcnJpZGUiOmZhbHNlfSwibWFjIjp7InNvdXJjZSI6eyJjb3VudCI6IjE2IiwibW9kZSI6IlRSZXggQ29uZmlnIiwic3RlcCI6IjEiLCJhZGRyZXNzIjoiMDA6MDA6MDA6MDA6MDA6MDAifSwiZGVzdGluYXRpb24iOnsiY291bnQiOiIxNiIsIm1vZGUiOiJUUmV4IENvbmZpZyIsInN0ZXAiOiIxIiwiYWRkcmVzcyI6IjAwOjAwOjAwOjAwOjAwOjAwIn19LCJpcHY0Ijp7InNvdXJjZSI6eyJjb3VudCI6IjE2IiwibW9kZSI6IkZpeGVkIiwic3RlcCI6IjEiLCJhZGRyZXNzIjoiMTYuMC4wLjEifSwiZGVzdGluYXRpb24iOnsiY291bnQiOiIxNiIsIm1vZGUiOiJGaXhlZCIsInN0ZXAiOiIxIiwiYWRkcmVzcyI6IjQ4LjAuMC4xIn19LCJ0Y3AiOnsiaXNfb3ZlcnJpZGVfZHN0X3BvcnQiOmZhbHNlLCJzcmNfcG9ydCI6IjEwMjUiLCJkc3RfcG9ydCI6IjEwMjUiLCJpc19vdmVycmlkZV9zcmNfcG9ydCI6ZmFsc2UsInNlcXVlbmNlX251bWJlciI6IjEyOTAxOCIsImFja19udW1iZXIiOiIwIiwiaXNfb3ZlcnJpZGVfY2hlY2tzdW0iOmZhbHNlLCJjaGVja3N1bSI6IkIzRTMiLCJ1cmdlbnRfcG9pbnRlciI6IjAiLCJpc191cmciOmZhbHNlLCJpc19hY2siOmZhbHNlLCJpc19wc2giOmZhbHNlLCJpc19yc3QiOmZhbHNlLCJpc19zeW5jIjpmYWxzZSwiaXNfZmluIjpmYWxzZSwid2luZG93IjoiMTAyNCJ9LCJ1ZHAiOnsiaXNfb3ZlcnJpZGVfZHN0X3BvcnQiOmZhbHNlLCJpc19vdmVycmlkZV9sZW5ndGgiOmZhbHNlLCJzcmNfcG9ydCI6IjEwMjUiLCJkc3RfcG9ydCI6IjEwMjUiLCJpc19vdmVycmlkZV9zcmNfcG9ydCI6ZmFsc2UsImlzX292ZXJyaWRlX2NoZWNrc3VtIjpmYWxzZSwiY2hlY2tzdW0iOiJGRkJBIiwibGVuZ3RoIjoiMjYifSwicGF5bG9hZCI6eyJ0eXBlIjoiRml4ZWQgV29yZCIsInBhdHRlcm4iOiIwMCJ9LCJ2bGFuIjp7ImlzX292ZXJyaWRlX3RwX2lkIjpmYWxzZSwidHBfaWQiOiJGRkZGIiwiY2ZpIjoiMCIsInZfaWQiOiIwIiwicHJpb3JpdHkiOiIwIn0sImFkdmFuc2VkX3Byb3BlcnRpZXMiOnsiY2FjaGVfdmFsdWUiOiI1MDAwIiwiY2FjaGVfc2l6ZV90eXBlIjoiQXV0byJ9LCJtb2RlbF92ZXJzaW9uIjoiMS4wIn0="
+      model: ""
+    self_start: true
+    advanced_mode: false
+    vm:
+      split_by_var: ""
+      instructions: []
+      cache_size: 5000
+  stream_id: 1


### PR DESCRIPTION
- Implemented lookup of "next" in imported native profiles
- Added option to enter name of duplicated profile (by default app tries to parse name of original profile, and increment index at the end, if it's not possible, just adding index at the end. If there is no another profile with same name (e.g. when you copy and paste streams to another traffic profile) user will not be prompted to enter new name.
- Added option to edit stream name from Table (Click to select stream, and click on Name to edit. Enter to accept new name, Esc or click to another element to discard changes).
- Fixed issue with same window titles in several dialogs.

![selection_009](https://user-images.githubusercontent.com/35273613/43562610-bb7d5338-9647-11e8-8fad-c06a404c4bd0.png)
